### PR TITLE
Fixed optional parameter exclude.

### DIFF
--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -196,7 +196,7 @@ def rebuild_pot_parser(subparsers):
                         dest='create_domain', required=False)
     parser.add_argument('-m', '--merge', metavar='filename', dest='merge_fn')
     parser.add_argument('--merge2', metavar='filename', dest='merge2_fn')
-    parser.add_argument('--exclude', metavar='"<ignore1> <ignore2> ..."')
+    parser.add_argument('--exclude', metavar='"<ignore1> <ignore2> ..."', default='')
     parser.add_argument('path', nargs='*')
     parser.set_defaults(func=rebuild_pot)
     return parser


### PR DESCRIPTION
Exception raised when used without exclude:

```
bin/i18ndude rebuild-pot --pot /Users/lukas/projects/opengever.core.dev/opengever/trash/locales/opengever.trash.pot --create opengever.trash ./opengever/trash
Traceback (most recent call last):
  File "bin/i18ndude", line 31, in <module>
    i18ndude.script.main()
  File "/Users/lukas/Plone/eggs/i18ndude-3.3.0-py2.7.egg/i18ndude/script.py", line 612, in main
    errors = arguments.func(arguments)
  File "/Users/lukas/Plone/eggs/i18ndude-3.3.0-py2.7.egg/i18ndude/script.py", line 210, in rebuild_pot
    exclude = tuple(arguments.exclude.split())
```
