### PR TITLE
Split tests and add a setUp and tearDown methods

### DIFF
--- a/src/i18ndude/tests/test_utils.py
+++ b/src/i18ndude/tests/test_utils.py
@@ -1,25 +1,33 @@
 # -*- coding: utf-8 -*-
-import unittest
+from i18ndude.utils import wrapString
 
-from i18ndude.utils import wrapString, MAX_WIDTH
+import i18ndude.utils
+import unittest
 
 
 class TestUtils(unittest.TestCase):
 
-    def test_wrapString(self):
-        # We can change the WRAP and MAX_WIDTH settings by using
-        # command line options.  We save the original here.
-        import i18ndude.utils
-        orig_max_width = i18ndude.utils.MAX_WIDTH
-        orig_wrap = i18ndude.utils.WRAP
+    def setUp(self):
+        self.original_max_width = i18ndude.utils.MAX_WIDTH
+        self.original_wrap = i18ndude.utils.WRAP
 
-        # By default we do not wrap.
+        # Enable wrapping.
+        i18ndude.utils.WRAP = True
+
+    def tearDown(self):
+        i18ndude.utils.MAX_WIDTH = self.original_max_width
+        i18ndude.utils.WRAP = self.original_wrap
+
+    def test_wrapString_no_wrapping(self):
+        # Disable wrapping.
+        i18ndude.utils.WRAP = False
+
         line = 'a'*50 + ' ' + 'b'*50
         self.assertEqual(wrapString(line),
                          ['a'*50 + ' ' + 'b'*50])
 
-        # That is not very interesting, so we enable wrapping for the
-        # rest of the test.
+    def test_wrapString_wrapping_single_line(self):
+        # Enable wrapping.
         i18ndude.utils.WRAP = True
 
         # This all fits on one line.
@@ -27,7 +35,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(wrapString('a'), ['a'])
         self.assertEqual(wrapString('a b'), ['a b'])
 
-        # This no longer fits.
+    def test_wrapString_wrapping_multiline(self):
+        # This does not fit on a single line.
         line = 'a'*20 + ' ' + 'b'*50 + ' ' + 'c'*20+ ' ' + 'd'*50
         self.assertEqual(wrapString(line),
                          ['',
@@ -36,7 +45,7 @@ class TestUtils(unittest.TestCase):
 
         # Look for the maximum that can fit on a single line.  This is
         # the maximum width, minus a starting and ending quote.
-        max_one_line = MAX_WIDTH - 2
+        max_one_line = i18ndude.utils.MAX_WIDTH - 2
         line = 'a'*40 + ' ' + 'b'*36
         self.assertEqual(len(line), max_one_line)
         self.assertEqual(wrapString(line), [line])
@@ -48,7 +57,8 @@ class TestUtils(unittest.TestCase):
                           'a'*40 + ' ',
                           'b'*37])
 
-        # So, what happens when some words are really too long?
+    def test_wrapString_wrapping_long_words(self):
+        # What happens when some words are really too long?
         A = 'a'*99
         B = 'b'*99
         C = 'c'*99
@@ -67,10 +77,6 @@ class TestUtils(unittest.TestCase):
         # If this is 2 or less, we do not wrap lines.
         i18ndude.utils.MAX_WIDTH = 2
         self.assertEqual(wrapString('aaa aaaaa'), ['aaa aaaaa'])
-
-        # Restory the original settings.
-        i18ndude.utils.MAX_WIDTH = orig_max_width
-        i18ndude.utils.WRAP = orig_wrap
 
 
 def test_suite():


### PR DESCRIPTION
To make it easier to add new tests and also make it more obvious where it fails I split the tests into smaller tests and added a `setUp` and `tearDown` methods to keep the `MAX_WIDTH` and `WRAP` always as the default values.
