### PR TITLE
Reuse endElement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``nosummary`` option from ``find-untranslated``.
+  It was reporting wrong information.
+  [gforcada]
 
 
 3.4.2 (2015-07-16)

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -236,21 +236,6 @@ class VerboseHandler(Handler):
 
 class NoSummaryVerboseHandler(Handler):
 
-    def endElement(self, tag):
-        tag, attrs, data = self._history.pop()
-        data = data.strip()
-
-        if _translatable(data):
-            # not enclosed
-            if (self._i18nlevel == 0) and not tag in ['script', 'style']:
-                severity = _severity(tag, attrs) or ''
-                if severity and severity != 'WARNING':
-                    self.log('i18n:translate missing for this:\n'
-                             '"""\n%s\n"""' % (data,), severity)
-
-        if self._i18nlevel != 0:
-            self._i18nlevel -= 1
-
     def log(self, msg, severity):
         Handler.log(self, msg, severity)
 


### PR DESCRIPTION
NoSummaryVerboseHandler had its own version of endElement that lacked
behind the generic Handler one.

I don't see a particular reason to keep its own version.

Fixes https://github.com/collective/i18ndude/issues/17