### PR TITLE
Use lxml in find-untranslated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 New:
 
-- *add item here*
+- Use lxml instead of xml.etree or elementtree for parsing
+  GenericSetup xml files.
+  [maurits]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,15 @@ Changelog
 
 New:
 
+- In the find-untranslated command, first try to parse a template as
+  xml, which is good for non-html files.  If that fails, try to parse
+  it as html with a little help from the lxml HTMLPaser, which handles
+  html5 code much better.  If that fails, use our trusty home grown
+  ``common.prepare_xml`` function, which treats everything as old
+  html.  Note that we still use ``xml.sax`` as the core parser here.
+  Issue #15
+  [maurits]
+
 - Ignore hidden files in the find-untranslated command.
   Issue #29
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ Changelog
 
 New:
 
-- Use lxml instead of xml.etree or elementtree for parsing
-  GenericSetup xml files.
+- Ignore hidden files in the find-untranslated command.
+  Issue #29
   [maurits]
 
 Fixes:

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,9 @@ install_requires = [
     'zope.i18nmessageid >= 3.3',
     'plone.i18n',
     'ordereddict',
+    'lxml',
 ]
 
-if sys.version_info < (2, 5):
-    install_requires.append('elementtree')
 if sys.version_info < (2, 7):
     # Python 2.7 contains argparse.  For earlier versions we need to
     # add it as a dependency.

--- a/src/i18ndude/catalog.py
+++ b/src/i18ndude/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from i18ndude import common
+from i18ndude.utils import quote
 from i18ndude.utils import wrapAndQuoteString
 from i18ndude.utils import wrapString
 from ordereddict import OrderedDict
@@ -292,10 +292,10 @@ class MessageCatalog(OrderedDict):
         and overwrites the comments with the ones from the given catalog. This
         is used in the sync command.
         """
-        removed_msgids = [common.quote(msgid)
+        removed_msgids = [quote(msgid)
                           for msgid in self.accept_ids(msgctl.keys())]
         self.overwrite_context(msgctl)
-        added_msgids = [common.quote(msgid)
+        added_msgids = [quote(msgid)
                         for msgid in self.add_missing(msgctl)]
 
         self.mime_header[

--- a/src/i18ndude/common.py
+++ b/src/i18ndude/common.py
@@ -1,3 +1,4 @@
+from lxml import etree
 from StringIO import StringIO
 import re
 
@@ -9,6 +10,7 @@ DEFAULT_DECL = {
 
     '<?xml': '<?xml version="1.0" encoding="utf-8"?>'
 }
+HTML_PARSER = etree.HTMLParser()
 
 
 def prepare_xml(file):
@@ -55,3 +57,45 @@ def prepare_xml(file):
                 '</body></html>')
 
     return StringIO(content.strip())
+
+
+def tree_content(tree):
+    content = etree.tostring(tree)
+    if content is None:
+        return
+    return StringIO(content.strip())
+
+
+def present_file_contents(filename):
+    """Present the file in various ways.
+
+    It is hard to parse files that may be plain html, plain xml, or a
+    page template.  It does not help that the page template might miss
+    namespaces so it gives an xml parse error.  Or it has html5-style
+    attributes that cannot be parsed by xml.sax but need to be smoothed
+    over by an html parser.  And this html parser may introduce double
+    attributes, like adding an xml:lang when this is already there in
+    the original template.
+
+    So we we present the file in various way, that other code can
+    iterate over.
+    """
+    errors = []
+    # First try to parse as nice xml.
+    try:
+        tree = etree.parse(filename)
+    except etree.XMLSyntaxError as error:
+        errors.append(error)
+    else:
+        yield tree_content(tree)
+    # If that fails, try to parse it as html.
+    try:
+        tree = etree.parse(filename, HTML_PARSER)
+    except etree.XMLSyntaxError as error:
+        errors.append(error)
+    else:
+        yield tree_content(tree)
+    # Try our (t)rusty old way.
+    yield prepare_xml(open(filename))
+    # Give back any errors we found.
+    yield errors

--- a/src/i18ndude/common.py
+++ b/src/i18ndude/common.py
@@ -55,12 +55,3 @@ def prepare_xml(file):
                 '</body></html>')
 
     return StringIO(content.strip())
-
-
-def quote(s):
-    """Quote if string has spaces."""
-
-    if [ch for ch in s if ch.isspace()]:
-        return '"%s"' % s
-    else:
-        return s

--- a/src/i18ndude/common.py
+++ b/src/i18ndude/common.py
@@ -82,19 +82,14 @@ def present_file_contents(filename):
     """
     errors = []
     # First try to parse as nice xml.
-    try:
-        tree = etree.parse(filename)
-    except etree.XMLSyntaxError as error:
-        errors.append(error)
-    else:
-        yield tree_content(tree)
     # If that fails, try to parse it as html.
-    try:
-        tree = etree.parse(filename, HTML_PARSER)
-    except etree.XMLSyntaxError as error:
-        errors.append(error)
-    else:
-        yield tree_content(tree)
+    for parser in (None, HTML_PARSER):
+        try:
+            tree = etree.parse(filename, parser)
+        except etree.XMLSyntaxError as error:
+            errors.append(error)
+        else:
+            yield tree_content(tree)
     # Try our (t)rusty old way.
     yield prepare_xml(open(filename))
     # Give back any errors we found.

--- a/src/i18ndude/gsextract.py
+++ b/src/i18ndude/gsextract.py
@@ -1,10 +1,6 @@
 import sys
 
-try:
-    from xml.etree.ElementTree import ElementTree
-    ElementTree  # pyflakes
-except ImportError:
-    from elementtree.ElementTree import ElementTree
+from lxml import etree
 
 from i18ndude.extract import find_files
 
@@ -25,7 +21,7 @@ class GSParser(object):
     def parse(self, filename):
         self.filename = filename
         try:
-            tree = ElementTree(file=filename)
+            tree = etree.parse(filename)
         except Exception as e:
             print u"There was an error in parsing %s: %s" % (filename, e)
             sys.exit(0)

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -73,15 +73,20 @@ def filter_isfile(files):
     for name in files:  # parse file by file
         name = name.strip()
         if os.path.isdir(name):  # descend recursively
-            join = lambda file: os.path.join(name, file)
-            subdirs = filter_isfile([path for path in
-                                     map(join, os.listdir(name))
-                                     if os.path.isdir(path) or
-                                     os.path.splitext(path)[1].endswith('pt')])
-            result += subdirs
+            subdirs = []
+            for subpath in os.listdir(name):
+                if subpath.startswith('.'):
+                    # ignore hidden file
+                    continue
+                path = os.path.join(name, subpath)
+                if (os.path.isdir(path) or
+                        os.path.splitext(subpath)[1].endswith('pt')):
+                    subdirs.append(path)
+            result += filter_isfile(subdirs)
 
         elif not os.path.isfile(name):
-            print >> sys.stderr, 'Warning: %s is not a file or is ignored.' % name  # noqa
+            print >> sys.stderr, (
+                'Warning: %s is not a file or is ignored.' % name)
 
         else:
             result.append(name)

--- a/src/i18ndude/tests/input/test1.pt
+++ b/src/i18ndude/tests/input/test1.pt
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
       lang="en"
       metal:use-macro="here/main_template/macros/master"

--- a/src/i18ndude/utils.py
+++ b/src/i18ndude/utils.py
@@ -256,3 +256,12 @@ def prepare_cli_documentation(data):
             msg = "Wrote command line documentation."
             commit_cmd = vcs.cmd_commit(msg)
             print execute_command(commit_cmd)
+
+
+def quote(s):
+    """Quote if string has spaces."""
+
+    if [ch for ch in s if ch.isspace()]:
+        return '"%s"' % s
+    else:
+        return s


### PR DESCRIPTION
The core still uses `xml.sax`, but lxml is used to cleanup the content so `xml.sax` has a better chance of not crashing on perceived syntax errors.