### PR TITLE
Fix some reported line numbers in find-untranslated.

### DIFF
--- a/src/i18ndude/common.py
+++ b/src/i18ndude/common.py
@@ -81,7 +81,10 @@ def present_file_contents(filename):
     iterate over.
     """
     errors = []
-    # First try to parse as nice xml.
+    # First try our (t)rusty old way, as that reports the original line
+    # numbers.
+    yield prepare_xml(open(filename))
+    # Then try to parse as nice xml.
     # If that fails, try to parse it as html.
     for parser in (None, HTML_PARSER):
         try:
@@ -90,7 +93,5 @@ def present_file_contents(filename):
             errors.append(error)
         else:
             yield tree_content(tree)
-    # Try our (t)rusty old way.
-    yield prepare_xml(open(filename))
     # Give back any errors we found.
     yield errors

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -136,12 +136,12 @@ def find_untranslated(arguments):
     # disable external validation to make it work without network access
     parser.setFeature(xml.sax.handler.feature_external_ges, False)
     parser.setFeature(xml.sax.handler.feature_external_pes, False)
-    handler = untranslated.VerboseHandler(parser, sys.stdout)  # default
+    handler = untranslated.VerboseHandler(parser)  # default
 
     if arguments.silent:
-        handler = untranslated.SilentHandler(parser, sys.stdout)
+        handler = untranslated.SilentHandler(parser)
     elif arguments.nosummary:
-        handler = untranslated.NoSummaryVerboseHandler(parser, sys.stdout)
+        handler = untranslated.NoSummaryVerboseHandler(parser)
 
     parser.setContentHandler(handler)
 
@@ -177,8 +177,12 @@ def find_untranslated(arguments):
             else:
                 # We have successfully parsed the file.
                 success = True
+                # We can safely print the output.
+                handler.show_output()
                 # No need for a run with another parser.
                 break
+            finally:
+                handler.clear_output()
         # Note that the error stats of the handler get reset to zero
         # when starting on a new document, so we ask about errors
         # after each document.

--- a/src/i18ndude/tests/input/test4.pt
+++ b/src/i18ndude/tests/input/test4.pt
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      lang="en"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="testing">
+
+<head>
+</head>
+
+<body>
+
+<p id="foo"
+   class="bar">We want this reported with the correct line number, 16, though this may be tricky. See issue 34.</p>
+
+</body>
+</html>

--- a/src/i18ndude/tests/test_untranslated.py
+++ b/src/i18ndude/tests/test_untranslated.py
@@ -1,6 +1,7 @@
 """Tests for finding untranslated prose.
 """
 import os
+import sys
 import unittest
 import xml.sax
 import StringIO
@@ -88,9 +89,23 @@ class TestUntranslatedScript(unittest.TestCase):
                 silent=False, nosummary=False, files=[path]))
         self.assertEqual(result, 1)
 
+    def test_script_template_4(self):
+        path = os.path.join(TEST_DIR, 'input', 'test4.pt')
+        output = StringIO.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = output
+        try:
+            result = script(Namespace(
+                silent=False, nosummary=False, files=[path]))
+        finally:
+            sys.stdout = old_stdout
+        self.assertEqual(result, 1)
+        # A specific line should be reported as missing an i18n.
+        self.assertIn('{}:16'.format(path), output.getvalue())
+
     def test_script_directory(self):
         path = os.path.join(TEST_DIR, 'input')
         with suppress_stdout():
             result = script(Namespace(
                 silent=False, nosummary=False, files=[path]))
-        self.assertEqual(result, 1)
+        self.assertEqual(result, 2)

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -1,3 +1,4 @@
+import StringIO
 import xml.sax
 
 IGNORE_UNTRANSLATED = 'i18n:ignore'
@@ -139,10 +140,21 @@ def attr_validator(tag, attrs, logfct):
 
 class Handler(xml.sax.ContentHandler):
 
-    def __init__(self, parser, out):
+    def __init__(self, parser, out=None):
         self._parser = parser
-        self._out = out
+        if out is None:
+            self._out = StringIO.StringIO()
+        else:
+            self._out = out
         self._filename = 'Undefined'
+
+    def show_output(self):
+        value = self._out.getvalue().strip()
+        if value:
+            print(value.encode('utf-8') + b'\n')
+
+    def clear_output(self):
+        self._out = StringIO.StringIO()
 
     def log(self, msg, severity):
         """Severity may be one out of 'WARNING', 'ERROR' or 'FATAL'."""


### PR DESCRIPTION
First try our (t)rusty old way, as that reports the original line numbers.

Using lxml may lead to wrongly reported line numbers, as serializing
means a tag always ends up on one line, where originally it may have
been on multiple lines.

Fixes issue #34.