### PR TITLE
Use regular expressions for --exclude parameter [take 2]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 New:
 
-- *add item here*
+- Allow use of regular expressions for --exclude parameter. For example,
+  use ".*\.py" to exclude all python files. This doesn't break existing
+  behavior.
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,9 @@ Changelog
 New:
 
 - Allow use of regular expressions for --exclude parameter. For example,
-  use ".*\.py" to exclude all python files. This doesn't break existing
-  behavior.
+  use "*.py" to exclude all python files. This doesn't break existing
+  behavior.  Do remember to use quotes around the expression.
+  [laulaz, maurits]
 
 Fixes:
 

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -94,9 +94,10 @@ rebuild-pot
       from this additional pot-file. If you provide a second pot-file via
       --merge2 <filename> I'll merge this into the first merge's result
 
-      You can also provide a list of filenames which should not be included
-      by using the --exclude argument, which takes a whitespace delimited
-      list of files.
+      You can also provide a list of filenames (or regular expressions for
+      filenames) which should not be included by using the --exclude argument,
+      which takes a whitespace delimited list of files (or regular expressions
+      for files).
       
 
   positional arguments:

--- a/src/i18ndude/extract.py
+++ b/src/i18ndude/extract.py
@@ -26,6 +26,7 @@ from zope.interface import implements
 import codecs
 import fnmatch
 import os
+import re
 import sys
 import time
 import tokenize
@@ -419,7 +420,8 @@ def find_files(dir, pattern, exclude=()):
         folders = (dir, )
 
     def visit(files, dirname, names):
-        names[:] = filter(lambda x: x not in exclude, names)
+        names[:] = filter(lambda x: all(not re.match(e, x) for e in exclude),
+                          names)
         files += [os.path.join(dirname, name)
                   for name in fnmatch.filter(names, pattern)
                   if name not in exclude]

--- a/src/i18ndude/extract.py
+++ b/src/i18ndude/extract.py
@@ -26,7 +26,6 @@ from zope.interface import implements
 import codecs
 import fnmatch
 import os
-import re
 import sys
 import time
 import tokenize
@@ -420,11 +419,10 @@ def find_files(dir, pattern, exclude=()):
         folders = (dir, )
 
     def visit(files, dirname, names):
-        names[:] = filter(lambda x: all(not re.match(e, x) for e in exclude),
-                          names)
+        for ex in exclude:
+            names[:] = filter(lambda x: not fnmatch.fnmatch(x, ex), names)
         files += [os.path.join(dirname, name)
-                  for name in fnmatch.filter(names, pattern)
-                  if name not in exclude]
+                  for name in fnmatch.filter(names, pattern)]
 
     for folder in folders:
         if os.path.isdir(folder):

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -229,9 +229,10 @@ def rebuild_pot_parser(subparsers):
     from this additional pot-file. If you provide a second pot-file via
     --merge2 <filename> I'll merge this into the first merge's result
 
-    You can also provide a list of filenames which should not be included
-    by using the --exclude argument, which takes a whitespace delimited
-    list of files.
+    You can also provide a list of filenames (or regular expressions for
+    filenames) which should not be included by using the --exclude argument,
+    which takes a whitespace delimited list of files (or regular expressions
+    for files).
     """
     parser = subparsers.add_parser(
         'rebuild-pot',


### PR DESCRIPTION
This is a version of pull request #39 using `fnmatch` instead of `re`.
