### PR TITLE
Moved ``plone.i18n`` dependency to a ``plone`` extra.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Moved ``plone.i18n`` dependency to a ``plone`` extra.
+  This is only used for getting language names in the ``list`` command.
+  We now fall back to using the language name that is in the ``po`` files.
+  Fixes `issue #44 <https://github.com/collective/i18ndude/issues/44>`_.
+  [maurits]
 
 
 4.2 (2017-06-21)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,14 +1,8 @@
 [buildout]
-extensions = mr.developer
-extends = http://download.zope.org/zopetoolkit/index/1.1.6/ztk-versions.cfg
 develop = .
 parts = interpreter test
-sources = sources
 versions = versions
 show-picked-versions = true
-
-[sources]
-zope.tal = git git@github.com:zopefoundation/zope.tal.git
 
 [interpreter]
 recipe = zc.recipe.egg
@@ -21,13 +15,15 @@ defaults = ['--auto-color', '--auto-progress']
 eggs = i18ndude
 
 [versions]
-Unidecode = 0.4.18
+lxml = 3.8.0
 ordereddict = 1.1
-plone.i18n = 3.0.2
-setuptools = 33.1.1
-zc.buildout = 2.9.3
+setuptools = 36.2.0
+six = 1.10.0
+zc.buildout = 2.9.4
 zc.recipe.egg = 2.0.3
 zc.recipe.testrunner = 2.0.0
-# With zope.tal 4.0.0 or higher we get a proper warning that we can
-# catch in one of the tests.  Works fine with other versions too.
-zope.tal = 4.1.1
+zope.exceptions = 4.1.0
+zope.i18nmessageid = 4.1.0
+zope.interface = 4.4.2
+zope.tal = 4.2.0
+zope.testrunner = 4.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==2.9.3
-setuptools==33.1.1
+zc.buildout==2.9.4
+setuptools==36.2.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ install_requires = [
     'zope.tal >= 3.5.2',
     'zope.interface >= 3.3',
     'zope.i18nmessageid >= 3.3',
-    'plone.i18n',
     'ordereddict',
     'lxml',
 ]
@@ -52,6 +51,9 @@ setup(
     zip_safe=False,
     test_suite='i18ndude.tests',
     install_requires=install_requires,
+    extras_require={
+        'plone': ['plone.i18n'],
+    },
     entry_points={
         'console_scripts': [
             'i18ndude=i18ndude.script:main',

--- a/src/i18ndude/visualisation.py
+++ b/src/i18ndude/visualisation.py
@@ -66,7 +66,12 @@ def output_table(out, languagelist, total):
             table += print_row(out[code]['percentage'], out[code]['desc'])
             del out[code]
         else:
-            desc = '%s (%s)' % (languagelist.get(code)['name'], code)
+            lang = languagelist.get(code)
+            if lang is None:
+                name = code
+            else:
+                name = lang['name']
+            desc = '%s (%s)' % (name, code)
             table += print_row(0, desc)
 
     body += _TABLE % dict(table=table)
@@ -78,7 +83,12 @@ def output_table(out, languagelist, total):
             table += print_row(out[code]['percentage'], out[code]['desc'])
             del out[code]
         else:
-            desc = '%s (%s)' % (languagelist.get(code)['name'], code)
+            lang = languagelist.get(code)
+            if lang is None:
+                name = code
+            else:
+                name = lang['name']
+            desc = '%s (%s)' % (name, code)
             table += print_row(0, desc)
 
     body += _TABLE % dict(table=table)
@@ -116,7 +126,12 @@ def output_list(out, languagelist, total):
             aligned_print(out[code]['percentage'], out[code]['desc'])
             del out[code]
         else:
-            desc = '%s (%s)' % (languagelist.get(code)['name'], code)
+            lang = languagelist.get(code)
+            if lang is None:
+                name = code
+            else:
+                name = lang['name']
+            desc = '%s (%s)' % (name, code)
             aligned_print(0, desc)
 
     print '\nTier 2:\n'
@@ -125,7 +140,12 @@ def output_list(out, languagelist, total):
             aligned_print(out[code]['percentage'], out[code]['desc'])
             del out[code]
         else:
-            desc = '%s (%s)' % (languagelist.get(code)['name'], code)
+            lang = languagelist.get(code)
+            if lang is None:
+                name = code
+            else:
+                name = lang['name']
+            desc = '%s (%s)' % (name, code)
             aligned_print(0, desc)
 
     print '\nTier 3:\n'
@@ -138,8 +158,11 @@ def output_list(out, languagelist, total):
 
 
 def make_listing(pot, pos, table=False):
-    from plone.i18n.locales.languages import LanguageAvailability
-    languagelist = LanguageAvailability().getLanguages(combined=True)
+    try:
+        from plone.i18n.locales.languages import LanguageAvailabilityXXX
+        languagelist = LanguageAvailability().getLanguages(combined=True)
+    except ImportError:
+        languagelist = {}
 
     msgids = pot.keys()
     total = len(msgids)


### PR DESCRIPTION
This is only used for getting language names in the ``list`` command.
We now fall back to using the language name that is in the ``po`` files.

Fixes issue #44.

I have simplified the `buildout.cfg` with only the few pins that we really need.

When used in plone.app.locales with the original code, the result of `i18ndude list -p plone` looks like this:

```
Messages: 2771

Tier 1:

100% - English (en)
 92% - French (fr)
 92% - Italian (it)
 84% - German (de)
 79% - Spanish (es)
 98% - Dutch (nl)
 77% - Chinese (China) (zh-cn)
 95% - Chinese (Taiwan) (zh-tw)
 85% - Japanese (ja)
 10% - Korean (ko)
 90% - Portuguese (Brazil) (pt-br)
 75% - Russian (ru)
 56% - Polish (pl)
 51% - Turkish (tr)
 13% - Thai (th)
 38% - Arabic (ar)

Tier 2:

 62% - Swedish (sv)
 57% - Finnish (fi)
 84% - Danish (da)
 48% - Portuguese (pt)
 59% - Romanian (ro)
 36% - Hungarian (hu)
 40% - Hebrew (he)
 41% - Indonesian (id)
 68% - Czech (cs)
 28% - Greek (el)
 52% - Norwegian (no)
 46% - Vietnamese (vi)
 46% - Bulgarian (bg)
  9% - Croatian (hr)
 37% - Lithuanian (lt)
 53% - Slovak (sk)
  0% - Tagalog (tl)
 79% - Slovenian (sl)
 22% - Serbian (sr)
 62% - Catalan (ca)
 29% - Latvian (lv)
 83% - Ukrainian (uk)
  7% - Hindi (hi)

Tier 3:

 54% - Afrikaans (af)
  3% - Albanian (sq)
  8% - Armenian (hy)
100% - Basque (eu)
  8% - Bengali (bn)
 18% - Burmese (my)
 16% - Chinese (Hongkong) (zh-hk)
 52% - Esperanto (eo)
 17% - Estonian (et)
 17% - Furlan (fu)
 39% - Galician (gl)
 15% - Georgian (ka)
 15% - Kannada (kn)
 22% - Macedonian (mk)
  8% - Nynorsk (nn)
 18% - Persian (fa)
  8% - Tamil (ta)
  8% - Telugu (te)
 18% - Welsh (cy)
```

The new result without `plone.i18n` looks like this:

```
Messages: 2771

Tier 1:

100% - English (en)
 92% - French (fr)
 92% - Italiano (it)
 84% - Deutsch (de)
 79% - Español (es)
 98% - Nederlands (nl)
 77% - Chinese Simplified (zh-cn)
 95% - Traditional Chinese (zh-tw)
 85% - Japanese (ja)
 10% - 한국어 (ko)
 90% - Português do Brasil (pt-br)
 75% - Russian (ru)
 56% - Polish (pl)
 51% - Türkçe (tr)
 13% - Thai (th)
 38% - Arabic (ar)

Tier 2:

 62% - English (sv)
 57% - Suomeksi (fi)
 84% - Danish (da)
 48% - Português (pt)
 59% - Romanian (ro)
 36% - Magyar (hu)
 40% - עברית (he)
 41% - Bahasa Indonesia (id)
 68% - Czech (cs)
 28% - Ελληνικά (el)
 52% - Norsk (no)
 46% - Vietnamese (vi)
 46% - Bulgarian (bg)
  9% - Croatian (hr)
 37% - Lithuanian (lt)
 53% - Slovenčina (sk)
  0% - tl (tl)
 79% - Slovenian (sl)
 22% - Serbian (sr)
 62% - Catalan (ca)
 29% - Latviešu (lv)
 83% - Українська (uk)
  7% - Hindi (hi)

Tier 3:

 54% - Afrikaans (af)
  3% - Albanian (sq)
  8% - Armenian (hy)
100% - Basque (eu)
  8% - Bengali (bn)
 18% - Burmese (my)
 16% - Chinese(HongKong) (zh-hk)
 52% - Esperanto (eo)
 17% - Estonian (et)
 17% - Furlan (fu)
 39% - Galego (gl)
 15% - Georgian (ka)
 15% - Kannada (kn)
 22% - Macedonian (mk)
  8% - Nynorsk (nn)
 18% - Persian (fa)
  8% - Telugu (te)
 18% - Welsh (cy)
  8% - tamil (ta)
```

So this is not very different. When done in a client project with only Dutch (nl) translations, the new result is:

```
Messages: 24

Tier 1:

100% - English (en)
  0% - fr (fr)
  0% - it (it)
  0% - de (de)
  0% - es (es)
100% - Nederlands (nl)
  0% - zh-cn (zh-cn)
  0% - zh-tw (zh-tw)
  0% - ja (ja)
  0% - ko (ko)
  0% - pt-br (pt-br)
  0% - ru (ru)
  0% - pl (pl)
  0% - tr (tr)
  0% - th (th)
  0% - ar (ar)

Tier 2:

  0% - sv (sv)
  0% - fi (fi)
  0% - da (da)
  0% - pt (pt)
  0% - ro (ro)
  0% - hu (hu)
  0% - he (he)
  0% - id (id)
  0% - cs (cs)
  0% - el (el)
  0% - no (no)
  0% - vi (vi)
  0% - bg (bg)
  0% - hr (hr)
  0% - lt (lt)
  0% - sk (sk)
  0% - tl (tl)
  0% - sl (sl)
  0% - sr (sr)
  0% - ca (ca)
  0% - lv (lv)
  0% - uk (uk)
  0% - hi (hi)
```

Which I would say is fine. If anyone actually uses this, and wants the old results, you can `pip install i18ndude[plone]`.