### PR TITLE
In list command, show only stats for existing po files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-5.0.3 (unreleased)
+5.1.0 (unreleased)
 ------------------
 
 - In the ``list`` command, show only languages with existing po files,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 5.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- In the ``list`` command, show only languages with existing po files,
+  ordered by percentage.  A new ``--tiered`` option uses the traditional
+  behavior with languages in a specific order in three tiers.
+  [maurits]
 
 
 5.0.2 (2018-03-12)

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -213,18 +213,27 @@ list
 
 ::
 
-  usage: i18ndude list [-h] -p product [product ...] [-t]
+  usage: i18ndude list [-h] -p product [product ...] [-t] [--tiered]
 
       This will create a simple listing that displays how much of the
       combined products pot's is translated for each language. Run this
       from the directory containing the pot-files. The product name is
       normally a domain name.
+
+      By default we show the languages of existing po files,
+      ordered by percentage.
+
+      With the --tiered option, we split the languages in three tiers or groups,
+      the first two with languages that Plone was traditionally translated in,
+      in a hardcoded order, followed by other languages.
+      This was the default output for years.
       
 
   optional arguments:
     -h, --help            show this help message and exit
     -p product [product ...], --products product [product ...]
-    -t, --table
+    -t, --table           Output as html table
+    --tiered              Show in traditional three-tiered order
 
 trmerge
 -------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-version = '5.0.3.dev0'
+version = '5.1.0.dev0'
 
 install_requires = [
     'lxml',

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -618,6 +618,14 @@ def list_parser(subparsers):
     combined products pot's is translated for each language. Run this
     from the directory containing the pot-files. The product name is
     normally a domain name.
+
+    By default we show the languages of existing po files,
+    ordered by percentage.
+
+    With the --tiered option, we split the languages in three tiers or groups,
+    the first two with languages that Plone was traditionally translated in,
+    in a hardcoded order, followed by other languages.
+    This was the default output for years.
     """
     parser = subparsers.add_parser(
         'list',
@@ -626,7 +634,12 @@ def list_parser(subparsers):
     )
     parser.add_argument('-p', '--products', metavar='product', nargs='+',
                         required=True)
-    parser.add_argument('-t', '--table', action='store_true')
+    parser.add_argument(
+        '-t', '--table', action='store_true',
+        help="Output as html table")
+    parser.add_argument(
+        '--tiered', action='store_true',
+        help="Show in traditional three-tiered order")
     parser.set_defaults(func=arg_list)
     return parser
 
@@ -634,6 +647,7 @@ def list_parser(subparsers):
 def arg_list(arguments):
     table = arguments.table
     products = arguments.products
+    tiered = arguments.tiered
 
     # get all the files
     pos = {}
@@ -679,7 +693,8 @@ def arg_list(arguments):
     for key in keys:
         po_catalogs.append(po_ctls[key])
 
-    visualisation.make_listing(pot_ctl, po_catalogs, table=table)
+    visualisation.make_listing(
+        pot_ctl, po_catalogs, table=table, tiered=tiered)
 
 
 def main():


### PR DESCRIPTION
Order the languages by percentage.
The traditional approach with the three tiers is available in the new option `--tiered`.
Works for both the standard list and the html table.
The list gives something like this (Plone 4.3):

```
$ i18ndude list -p plone
Messages: 2566

100% - Basque (eu)
 98% - Português do Brasil (pt-br)
 97% - Italiano (it)
 97% - Español (es)
 97% - Traditional Chinese (zh-tw)
 97% - French (fr)
 97% - Українська (uk)
 94% - Danish (da)
 93% - Czech (cs)
 93% - Slovenian (sl)
 92% - Nederlands (nl)
```

This is for master. Might be backported to 4.x, but locally I am always using master.