### PR TITLE
find-untranslated no longer complains about chameleon attributes [4.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- ``find-untranslated`` no longer complains about attributes with chameleon syntax.
+  An html tag with ``title="${context/Description}"`` is no longer
+  marked as having an untranslated title tag.
+  Fixes `issue 53 <https://github.com/collective/i18ndude/issues/53>`_.
+  [maurits]
 
 
 4.3 (2017-07-31)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,9 +17,9 @@ eggs = i18ndude
 [versions]
 lxml = 3.8.0
 ordereddict = 1.1
-setuptools = 36.2.0
+setuptools = 39.0.1
 six = 1.10.0
-zc.buildout = 2.9.4
+zc.buildout = 2.11.2
 zc.recipe.egg = 2.0.3
 zc.recipe.testrunner = 2.0.0
 zope.exceptions = 4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==2.9.4
-setuptools==36.2.0
+setuptools==39.0.1
+zc.buildout==2.11.2

--- a/src/i18ndude/tests/input/chameleon.pt
+++ b/src/i18ndude/tests/input/chameleon.pt
@@ -1,0 +1,8 @@
+<div foo="fine" alt="fine" title="${context/Description}">${context/Title}</div>
+<img foo="fine" alt="${context/Description}" title="${context/Description}" />
+<input foo="fine" alt="fine" placeholder="${context/Description}"
+       type="text" value="fine" title="${context/Description}" />
+<input foo="fine" alt="fine" type="submit" value="${context/Description}"
+       title="${context/Description}" />
+<input foo="fine" alt="fine" type="button" value="${context/Description}"
+       title="${context/Description}" />

--- a/src/i18ndude/tests/test_untranslated.py
+++ b/src/i18ndude/tests/test_untranslated.py
@@ -147,6 +147,13 @@ class TestUntranslatedScript(unittest.TestCase):
         # A specific line should be reported as missing an i18n.
         self.assertIn('{}:16'.format(path), output.getvalue())
 
+    def test_script_chameleon(self):
+        path = os.path.join(TEST_DIR, 'input', 'chameleon.pt')
+        with suppress_stdout():
+            result = script(Namespace(
+                silent=False, nosummary=False, files=[path]))
+        self.assertEqual(result, 0)
+
     def test_script_directory(self):
         path = os.path.join(TEST_DIR, 'input')
         with suppress_stdout():

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -70,6 +70,10 @@ def _tal_replaced_content(tag, attrs):
 def _tal_replaced_attr(attrs, attr):
     # Is the attribute replaced by tal?
     if 'tal:attributes' not in attrs and 'attributes' not in attrs:
+        # Not replaced by tal, but could be chameleon syntax.
+        value = attrs.get(attr, '')
+        if CHAMELEON_SUBST.match(value):
+            return True
         return False
     talattrs = [talattr.strip().split()[0] for talattr in
                 attrs['tal:attributes'].split(';') if talattr]


### PR DESCRIPTION
An html tag with `title="${context/Description}"` is no longer marked as having an untranslated title tag.
Fixes https://github.com/collective/i18ndude/issues/53

Backport of #57 to 4.x.