### PR TITLE
Fixed another possible UnicodeDecodeError in find-untranslated.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.0.3 (unreleased)
 ------------------
 
+- Fixed another possible UnicodeDecodeError in find-untranslated.
+  [maurits]
+
 - ``find-untranslated`` no longer complains about attributes with chameleon syntax.
   An html tag with ``title="${context/Description}"`` is no longer
   marked as having an untranslated title tag.

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -150,7 +150,12 @@ def find_untranslated(arguments):
     errors = 0
     for filename in filter_isfile(arguments.files):  # parse file by file
         with open(filename) as myfile:
-            if not myfile.read().strip():
+            try:
+                if not myfile.read().strip():
+                    continue
+            except UnicodeDecodeError:
+                print('ERROR: UnicodeDecodeError while reading {}'.format(
+                    filename))
                 continue
         # Reinitialize the handler, resetting errors.
         handler.set_filename(filename)


### PR DESCRIPTION
Can happen with a utf-16 encoded file, like this test file in CMFCore:
https://github.com/zopefoundation/Products.CMFCore/blob/2.3.0/Products/CMFCore/tests/fake_skins/fake_skin/testPT3.pt
Only happens with Python 3.