### PR TITLE
Sort files that we extract messages from.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 5.0.3 (unreleased)
 ------------------
 
+- Sort files that we extract messages from.
+  On Linux they were already sorted, but not on Mac, leading to a test failure.
+  [maurits]
+
 - Fixed another possible UnicodeDecodeError in find-untranslated.
   [maurits]
 

--- a/src/i18ndude/extract.py
+++ b/src/i18ndude/extract.py
@@ -448,7 +448,7 @@ def find_files(dir, pattern, exclude=()):
         else:
             if fnmatch.filter([folder], pattern):
                 files.append(folder)
-    return files
+    return sorted(files)
 
 # We don't want to assume a default domain of Zope
 # def py_strings(dir, domain="zope", exclude=()):


### PR DESCRIPTION
On Linux they were already sorted, but not on Mac, leading to a test failure.
Sample failure:

```
Failure in test test_read (i18ndude.tests.test_catalog.TestMessagePTReader)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/Users/maurits/tools/src/i18ndude/src/i18ndude/tests/test_catalog.py", line 509, in test_read
    (out[key], self.output[key]))
  File "/usr/local/Cellar/python/3.6.4_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/case.py", line 682, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true : Failure in pt parsing.
Got:some_alt, Some alt, ['/Users/maurits/tools/src/i18ndude/src/i18ndude/tests/input/test3.pt:15', '/Users/maurits/tools/src/i18ndude/src/i18ndude/tests/input/test1.pt:15'], [], []
Expected:some_alt, Some alt, ['/Users/maurits/tools/src/i18ndude/src/i18ndude/tests/input/test1.pt:15', '/Users/maurits/tools/src/i18ndude/src/i18ndude/tests/input/test3.pt:15'], [], []
```