### PR TITLE
Sort files that we extract messages from.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Sort files that we extract messages from.
+  On Linux they were already sorted, but not on Mac, leading to a test failure.
+  [maurits]
+
 - ``find-untranslated`` no longer complains about attributes with chameleon syntax.
   An html tag with ``title="${context/Description}"`` is no longer
   marked as having an untranslated title tag.

--- a/src/i18ndude/extract.py
+++ b/src/i18ndude/extract.py
@@ -430,7 +430,7 @@ def find_files(dir, pattern, exclude=()):
         else:
             if fnmatch.filter([folder], pattern):
                 files.append(folder)
-    return files
+    return sorted(files)
 
 # We don't want to assume a default domain of Zope
 # def py_strings(dir, domain="zope", exclude=()):


### PR DESCRIPTION
On Linux they were already sorted, but not on Mac, leading to a test failure.

Backport of #60 for 4.x.