### PR TITLE
Disallow non-word characters in i18n:name 

### DIFF
--- a/news/71.bugfix
+++ b/news/71.bugfix
@@ -1,2 +1,2 @@
-- Disallow non-word characters in i18n:name attributes when running
-  `find-untranslated` code analysis [gyst]
+- Disallow non-word characters (but do allow dashes) in i18n:name
+  attributes when running `find-untranslated` code analysis [gyst]

--- a/news/71.bugfix
+++ b/news/71.bugfix
@@ -1,0 +1,2 @@
+- Disallow non-word characters in i18n:name attributes when running
+  `find-untranslated` code analysis [gyst]

--- a/src/i18ndude/generator.py
+++ b/src/i18ndude/generator.py
@@ -10,7 +10,8 @@ from zope.tal.translationcontext import TranslationContext
 
 import re
 
-NOT_ALLOWED_IN_NAME = re.compile('[^\w-]')
+
+NOT_ALLOWED_IN_NAME = re.compile(r'[^\w-]')
 
 
 class DudeGenerator(TALGenerator):
@@ -257,7 +258,7 @@ class DudeGenerator(TALGenerator):
             # interested in compiling everything.  But we can try.
             # We look for tal:repeat="   (a,b,c) python:something"
             # in a way similar to zope.tal.
-            m = re.match("(?s)\s*(\(.+\))\s+(.*)\Z", arg)
+            m = re.match(r"(?s)\s*(\(.+\))\s+(.*)\Z", arg)
             if not m:
                 raise TALError("invalid repeat syntax: " + repr(arg),
                                self.position)

--- a/src/i18ndude/generator.py
+++ b/src/i18ndude/generator.py
@@ -10,7 +10,7 @@ from zope.tal.translationcontext import TranslationContext
 
 import re
 
-NOT_ALLOWED_IN_NAME = re.compile('\W')
+NOT_ALLOWED_IN_NAME = re.compile('[^\w-]')
 
 
 class DudeGenerator(TALGenerator):

--- a/src/i18ndude/generator.py
+++ b/src/i18ndude/generator.py
@@ -10,6 +10,8 @@ from zope.tal.translationcontext import TranslationContext
 
 import re
 
+NOT_ALLOWED_IN_NAME = re.compile('\W')
+
 
 class DudeGenerator(TALGenerator):
 
@@ -75,6 +77,11 @@ class DudeGenerator(TALGenerator):
             raise I18NError(
                 "i18n:name can only occur inside a translation unit",
                 position)
+
+        if varname and NOT_ALLOWED_IN_NAME.search(varname):
+            raise I18NError(
+                "i18n:name cannot contain non-word characters "
+                "(spaces, punctuation)", position)
 
         if i18ndata and not msgid:
             raise I18NError("i18n:data must be accompanied by i18n:translate",

--- a/src/i18ndude/tests/input/test1.pt
+++ b/src/i18ndude/tests/input/test1.pt
@@ -23,7 +23,7 @@
 <span i18n:translate="">
     <div i18n:name="foo"></div>
 
-    <div i18n:name="bar"></div>
+    <div i18n:name="with-dash-and_underscore"></div>
 </span>
 
 <p i18n:translate="text_buzz">Buzz</p>

--- a/src/i18ndude/tests/test_catalog.py
+++ b/src/i18ndude/tests/test_catalog.py
@@ -464,7 +464,7 @@ class TestMessagePTReader(unittest.TestCase):
         second_filename = self.input + os.sep + 'test3.pt'
         self.output = {
             u'Buzz': self.me(u'Buzz', references=[filename + ':21']),
-            u'${foo} ${bar}': self.me(u'${foo} ${bar}', references=[filename + ':26']),  # noqa
+            u'${foo} ${with-dash-and_underscore}': self.me(u'${foo} ${with-dash-and_underscore}', references=[filename + ':26']),  # noqa
             u'dig_this': self.me(u'dig_this', msgstr=u'Dig this', references=[filename + ':52']),  # noqa
             u'text_buzz': self.me(u'text_buzz', msgstr=u'Buzz', references=[filename + ':29', filename + ':31']),  # noqa
             u'some_alt': self.me(u'some_alt', msgstr=u'Some alt', references=[filename + ':15', second_filename + ':15']),  # noqa

--- a/src/i18ndude/tests/test_untranslated.py
+++ b/src/i18ndude/tests/test_untranslated.py
@@ -151,6 +151,12 @@ class TestUntranslated(unittest.TestCase):
             'invalid non-word characters (space, punctuation) in i18n:name',
             result_with_slash_in_name)
         self.assertIn('1 errors', result_with_slash_in_name)
+        result_with_dash_in_name = find_untranslated(
+            '<div i18n:translate="">Something <span i18n:name="x_foo-x_bar">amiss</span></div>')
+        self.assertNotIn(
+            'invalid non-word characters (space, punctuation) in i18n:name',
+            result_with_dash_in_name)
+        self.assertIn('0 errors', result_with_dash_in_name)
 
 
 class TestUntranslatedScript(unittest.TestCase):

--- a/src/i18ndude/tests/test_untranslated.py
+++ b/src/i18ndude/tests/test_untranslated.py
@@ -138,6 +138,20 @@ class TestUntranslated(unittest.TestCase):
             'lacks i18n:attributes',
             result_with_translated_aria_label)
 
+    def test_find_untranslated_disallows_nonword_chars_in_i18n_name(self):
+        result_with_space_in_name = find_untranslated(
+            '<div i18n:translate="">Something <span i18n:name="xfoo xbar">amiss</span></div>')
+        self.assertIn(
+            'invalid non-word characters (space, punctuation) in i18n:name',
+            result_with_space_in_name)
+        self.assertIn('1 errors', result_with_space_in_name)
+        result_with_slash_in_name = find_untranslated(
+            '<div i18n:translate="">Something <span i18n:name="xfoo/xbar">amiss</span></div>')
+        self.assertIn(
+            'invalid non-word characters (space, punctuation) in i18n:name',
+            result_with_slash_in_name)
+        self.assertIn('1 errors', result_with_slash_in_name)
+
 
 class TestUntranslatedScript(unittest.TestCase):
 

--- a/src/i18ndude/tests/test_untranslated.py
+++ b/src/i18ndude/tests/test_untranslated.py
@@ -139,23 +139,18 @@ class TestUntranslated(unittest.TestCase):
             result_with_translated_aria_label)
 
     def test_find_untranslated_disallows_nonword_chars_in_i18n_name(self):
+        error = 'invalid non-word characters (space, punctuation) in i18n:name'
         result_with_space_in_name = find_untranslated(
             '<div i18n:translate="">Something <span i18n:name="xfoo xbar">amiss</span></div>')
-        self.assertIn(
-            'invalid non-word characters (space, punctuation) in i18n:name',
-            result_with_space_in_name)
+        self.assertIn(error, result_with_space_in_name)
         self.assertIn('1 errors', result_with_space_in_name)
         result_with_slash_in_name = find_untranslated(
             '<div i18n:translate="">Something <span i18n:name="xfoo/xbar">amiss</span></div>')
-        self.assertIn(
-            'invalid non-word characters (space, punctuation) in i18n:name',
-            result_with_slash_in_name)
+        self.assertIn(error, result_with_slash_in_name)
         self.assertIn('1 errors', result_with_slash_in_name)
         result_with_dash_in_name = find_untranslated(
             '<div i18n:translate="">Something <span i18n:name="x_foo-x_bar">amiss</span></div>')
-        self.assertNotIn(
-            'invalid non-word characters (space, punctuation) in i18n:name',
-            result_with_dash_in_name)
+        self.assertNotIn(error, result_with_dash_in_name)
         self.assertIn('0 errors', result_with_dash_in_name)
 
 

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -9,8 +9,8 @@ if PY3:
 
 IGNORE_UNTRANSLATED = 'i18n:ignore'
 IGNORE_UNTRANSLATED_ATTRIBUTES = 'i18n:ignore-attributes'
-CHAMELEON_SUBST = re.compile('^\${.*}$')
-NOT_ALLOWED_IN_NAME = re.compile('[^\w-]')
+CHAMELEON_SUBST = re.compile(r'^\${.*}$')
+NOT_ALLOWED_IN_NAME = re.compile(r'[^\w-]')
 
 
 def _translatable(data):

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -10,6 +10,7 @@ if PY3:
 IGNORE_UNTRANSLATED = 'i18n:ignore'
 IGNORE_UNTRANSLATED_ATTRIBUTES = 'i18n:ignore-attributes'
 CHAMELEON_SUBST = re.compile('^\${.*}$')
+NOT_ALLOWED_IN_NAME = re.compile('\W')
 
 
 def _translatable(data):
@@ -153,6 +154,11 @@ def attr_validator(tag, attrs, logfct):
         if not _valid_i18ned_attr('placeholder', attrs):
             logfct('placeholder attribute of <%s> lacks i18n:attributes' % tag,
                    'ERROR')
+
+    name = attrs.get('i18n:name')
+    if name and NOT_ALLOWED_IN_NAME.search(name):
+        logfct('invalid non-word characters (space, punctuation) '
+               'in i18n:name="{}"'.format(name), 'ERROR')
 
 
 class Handler(xml.sax.ContentHandler):

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -10,7 +10,7 @@ if PY3:
 IGNORE_UNTRANSLATED = 'i18n:ignore'
 IGNORE_UNTRANSLATED_ATTRIBUTES = 'i18n:ignore-attributes'
 CHAMELEON_SUBST = re.compile('^\${.*}$')
-NOT_ALLOWED_IN_NAME = re.compile('\W')
+NOT_ALLOWED_IN_NAME = re.compile('[^\w-]')
 
 
 def _translatable(data):


### PR DESCRIPTION
Useful to catch errors during find-untranslated code analysis, fixes #71.