### PR TITLE
Added hint in `rebuild-pot` help about unwanted domains in Python files.

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,2 @@
+Added hint in ``rebuild-pot`` help about unwanted domains in Python files.
+[maurits]

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -229,6 +229,16 @@ def rebuild_pot_parser(subparsers):
     domain from the Domain header in the given pot file and keep the
     headers from the file as base for a new pot file.
 
+    Note that in Python files we simply look for text within an underscore
+    method: _("...").  We do not know which domain this is.
+    If this finds text from a domain that you do not want to find,
+    you should give the underscore method for the unwanted domain
+    a different name, for example:
+
+      from zope.i18nmessageid import MessageFactory
+      PMF = MessageFactory("plone")
+      PMF("...")
+
     If you give me an additional pot-file with the --merge <filename>
     option, I try to merge these msgids into the target-pot file
     afterwards. If a msgid already exists in the ones I found in the


### PR DESCRIPTION
This addresses the comment from @idgserpro in [buildout.plonetest](https://github.com/collective/buildout.plonetest/issues/49#issuecomment-523889665 )