### PR TITLE
Fixed filter command on Python 3.7, and possibly earlier.

### DIFF
--- a/news/75.bugfix
+++ b/news/75.bugfix
@@ -1,0 +1,2 @@
+Fixed filter command on Python 3.7, and possibly earlier.
+[maurits]

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -512,9 +512,15 @@ def filter(arguments):
     f1_ctl = catalog.MessageCatalog(filename=arguments.file1)
     f2_ctl = catalog.MessageCatalog(filename=arguments.file2)
 
+    # On Python 3.7 we can get an error if we delete immediately:
+    # RuntimeError: OrderedDict mutated during iteration
+    # So first gather items in a list.  That is better anyway.
+    to_delete = []
     for msgid in f1_ctl.keys():
         if msgid in f2_ctl:
-            del f1_ctl[msgid]
+            to_delete.append(msgid)
+    for msgid in to_delete:
+        del f1_ctl[msgid]
 
     writer = catalog.POWriter(sys.stdout, f1_ctl)
     writer.write(sort=False, msgstrToComment=True)


### PR DESCRIPTION
Fixes issue #75.
When I try the given command on EasyNewsletter tag 5.0.0a8, on master it fails, and on this PR branch it succeeds.