### PR TITLE
The list command was wrongly showing 100% translated

### DIFF
--- a/news/81.bugfix
+++ b/news/81.bugfix
@@ -1,0 +1,2 @@
+The list command was wrongly showing 100% translated when the translations were at 99%.
+[vincentfretin]

--- a/src/i18ndude/visualisation.py
+++ b/src/i18ndude/visualisation.py
@@ -211,8 +211,6 @@ def make_listing(pot, pos, table=False, tiered=False):
                     value += 1
 
         percentage = int(value / (total * 1.0) * 100)
-        if percentage == 99:
-            percentage = 100
         values[code] = dict(percentage=percentage, desc=desc)
 
     total = len(msgids)


### PR DESCRIPTION
This fixes i18n stats for Plone
https://github.com/plone/Products.CMFPlone/issues/3131