### PR TITLE
Support the define syntax from Chameleon.

### DIFF
--- a/news/36.bugfix
+++ b/news/36.bugfix
@@ -1,0 +1,4 @@
+Support the define syntax from Chameleon.
+This is for the unpacking syntax, for example ``tal:define="(text,url) python:view.linkinfo"``.
+This avoids ``TALError: invalid define syntax`` when extracting messages from templates that use this.
+[maurits]

--- a/src/i18ndude/generator.py
+++ b/src/i18ndude/generator.py
@@ -266,3 +266,9 @@ class DudeGenerator(TALGenerator):
             cexpr = self.compileExpression(expr)
             program = self.popProgram()
             self.emit("loop", name, cexpr, program)
+
+    def emitDefines(self, defines):
+        # Originally we did not have this method, so the one from zope.tal was used.
+        # This could give a 'TALError: invalid define syntax'.
+        # For the define case, we can actually ignore everything.
+        return

--- a/src/i18ndude/testdata/input/test5.pt
+++ b/src/i18ndude/testdata/input/test5.pt
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      lang="en"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="testing">
+<head>
+</head>
+<body>
+<!-- Some tests for rebuild-pot and Chameleon syntax -->
+<ul tal:repeat="(outer, inner) python:[('ch1', ['par11', 'par12']), ('ch2', ['par21'])]">
+  <li>${outer}</li>
+  <ul><li tal:repeat="inn inner">${inn}</li></ul>
+  <span i18n:translate="">rebuild-pot should not complain about Chameleon repeat syntax.</span>
+</ul>
+<div tal:define="(text,url) python:view.linkinfo">
+  <span i18n:translate="">rebuild-pot should not complain about Chameleon define syntax.</span>
+  <a href="${text}">${url}</a>
+</div>
+</body>
+</html>

--- a/src/i18ndude/tests/test_catalog.py
+++ b/src/i18ndude/tests/test_catalog.py
@@ -460,13 +460,14 @@ class TestMessagePTReader(unittest.TestCase):
         self.me = catalog.MessageEntry
         self.input = os.path.join(TESTDATA_DIR, 'input')
         filename = self.input + os.sep + 'test1.pt'
-        second_filename = self.input + os.sep + 'test3.pt'
+        filename3 = self.input + os.sep + 'test3.pt'
+        filename5 = self.input + os.sep + 'test5.pt'
         self.output = {
             u'Buzz': self.me(u'Buzz', references=[filename + ':21']),
             u'${foo} ${with-dash-and_underscore}': self.me(u'${foo} ${with-dash-and_underscore}', references=[filename + ':26']),  # noqa
             u'dig_this': self.me(u'dig_this', msgstr=u'Dig this', references=[filename + ':52']),  # noqa
             u'text_buzz': self.me(u'text_buzz', msgstr=u'Buzz', references=[filename + ':29', filename + ':31']),  # noqa
-            u'some_alt': self.me(u'some_alt', msgstr=u'Some alt', references=[filename + ':15', second_filename + ':15']),  # noqa
+            u'some_alt': self.me(u'some_alt', msgstr=u'Some alt', references=[filename + ':15', filename3 + ':15']),  # noqa
             u'title_some_alt': self.me(u'title_some_alt', msgstr=u'Some title', references=[filename + ':15']),  # noqa
             u'Job started at ${datetime} by user ${userid}.': self.me(u'Job started at ${datetime} by user ${userid}.', references=[filename + ':46']),  # noqa
             u'spacing': self.me(u'spacing', msgstr=u'Space <br /> before and after.', references=[filename + ':37']),  # noqa
@@ -475,6 +476,8 @@ class TestMessagePTReader(unittest.TestCase):
             u'odd': self.me(u'odd', references=[filename + ':58']),
             u'even': self.me(u'even', references=[filename + ':59']),
             u'Test for issue 15, html5 attributes without value': self.me(u'Test for issue 15, html5 attributes without value', references=[filename + ':62']),  # noqa
+            u'rebuild-pot should not complain about Chameleon repeat syntax.': self.me(u'rebuild-pot should not complain about Chameleon repeat syntax.', references=[filename5 + ':16']),  # noqa
+            u'rebuild-pot should not complain about Chameleon define syntax.': self.me(u'rebuild-pot should not complain about Chameleon define syntax.', references=[filename5 + ':19']),  # noqa
         }
 
     def test_read(self):


### PR DESCRIPTION
This is for the unpacking syntax, for example `tal:define="(text,url) python:view.linkinfo"`.
This avoids `TALError: invalid define syntax` when extracting messages from templates that use this.

Since 2017 we had a fix for this syntax in repeat statements, but not yet for the define statement.
Our fix for 'define' is actually much simpler than is needed for the repeat: we ignore all define statements.
i18ndude needs no info from these statements.

Fixes another part of https://github.com/collective/i18ndude/issues/36