### PR TITLE
Add --no-line-numbers option, default false (no behavior change).

### DIFF
--- a/news/77.feature
+++ b/news/77.feature
@@ -1,0 +1,2 @@
+Add ``--no-line-numbers`` option, default false (no behavior change).
+[maurits]

--- a/src/i18ndude/catalog.py
+++ b/src/i18ndude/catalog.py
@@ -682,12 +682,13 @@ class PTReader:
     """Reads in a list of page templates.
     """
 
-    def __init__(self, path, domain='none', exclude=()):
+    def __init__(self, path, domain='none', exclude=(), no_line_numbers=False):
 
         self.domain = domain
         self.catalogs = {}  # keyed by domain name
         self.path = path
         self.exclude = exclude
+        self.no_line_numbers = no_line_numbers
 
     def read(self):
         """Reads in from all given ZPTs and builds up MessageCatalogs accordingly.
@@ -704,10 +705,14 @@ class PTReader:
             msgstr = msgid.default or ''
 
             if msgid and msgid != '${DYNAMIC_CONTENT}':
+                if self.no_line_numbers:
+                    filenames = sorted(set([l[0] for l in tal[msgid]]))
+                else:
+                    filenames = [l[0] + ':' + str(l[1]) for l in tal[msgid]]
                 self._add_msg(msgid,
                               msgstr,
                               [],
-                              [l[0] + ':' + str(l[1]) for l in tal[msgid]],
+                              filenames,
                               [],
                               self.domain)
 
@@ -733,12 +738,13 @@ class PYReader:
     """Reads in a list of python scripts.
     """
 
-    def __init__(self, path, domain, exclude=()):
+    def __init__(self, path, domain, exclude=(), no_line_numbers=False):
 
         self.domain = domain
         self.catalogs = {}  # keyed by domain name
         self.path = path
         self.exclude = exclude
+        self.no_line_numbers = no_line_numbers
 
     def read(self):
         """Reads in from all given PYs and builds up MessageCatalogs
@@ -757,10 +763,14 @@ class PYReader:
                         exclude=self.exclude + ('tests', ))
 
         for msgid in py:
+            if self.no_line_numbers:
+                filenames = sorted(set([l[0] for l in py[msgid]]))
+            else:
+                filenames = [l[0] + ':' + str(l[1]) for l in py[msgid]]
             self._add_msg(msgid,
                           msgid.default or '',
                           [],
-                          [l[0] + ':' + str(l[1]) for l in py[msgid]],
+                          filenames,
                           [],
                           self.domain)
         return []
@@ -784,11 +794,13 @@ class GSReader(object):
     """Reads in a list of GenericSetup profile files.
     """
 
-    def __init__(self, path, domain, exclude=()):
+    def __init__(self, path, domain, exclude=(), no_line_numbers=False):
         self.domain = domain
         self.catalogs = {}  # keyed by domain name
         self.path = path
         self.exclude = exclude
+        # Note: the current extractor does not give us line numbers at all.
+        self.no_line_numbers = no_line_numbers
 
     def read(self):
         """Reads in from all given xml's and builds up MessageCatalogs
@@ -835,11 +847,12 @@ class ZCMLReader(object):
     """Reads in a list of ZCML files.
     """
 
-    def __init__(self, path, domain, exclude=()):
+    def __init__(self, path, domain, exclude=(), no_line_numbers=False):
         self.domain = domain
         self.catalogs = {}  # keyed by domain name
         self.path = path
         self.exclude = exclude
+        self.no_line_numbers = no_line_numbers
 
     def read(self):
         """Reads in from all given zcml's and builds up MessageCatalogs
@@ -859,10 +872,14 @@ class ZCMLReader(object):
 
         for domain in zcml:
             for msgid in zcml[domain]:
+                # We only have one filename.
+                filename = msgid[2]
+                if self.no_line_numbers:
+                    filename = filename.split(":")[0]
                 self._add_msg(msgid[0],
                               msgid[1],
                               [],
-                              [msgid[2]],
+                              [filename],
                               [],
                               domain)
         return []

--- a/src/i18ndude/script.py
+++ b/src/i18ndude/script.py
@@ -250,6 +250,13 @@ def rebuild_pot_parser(subparsers):
     filenames) which should not be included by using the --exclude argument,
     which takes a whitespace delimited list of files (or regular expressions
     for files).
+
+    By default we add a comment showing references to file paths and line numbers
+    that contain the message, like this:
+
+        #: ./browser.py:32
+
+    You can suppress the line numbers by using the --no-line-endings option.
     """
     parser = subparsers.add_parser(
         'rebuild-pot',
@@ -265,6 +272,8 @@ def rebuild_pot_parser(subparsers):
     parser.add_argument('--merge2', metavar='filename', dest='merge2_fn')
     parser.add_argument(
         '--exclude', metavar='"<ignore1> <ignore2> ..."', default='')
+    parser.add_argument('--no-line-numbers', action="store_true",
+                        dest='no_line_numbers', required=False)
     parser.add_argument('path', nargs='*')
     parser.set_defaults(func=rebuild_pot)
     return parser
@@ -281,6 +290,7 @@ def rebuild_pot(arguments):
     merge2_fn = arguments.merge2_fn
     if merge2_fn == merge_fn:
         merge2_fn = False
+    no_line_numbers = arguments.no_line_numbers
     path = arguments.path
 
     try:
@@ -293,10 +303,18 @@ def rebuild_pot(arguments):
             merge_ctl = catalog.MessageCatalog(filename=merge_fn)
         if merge2_fn:
             merge2_ctl = catalog.MessageCatalog(filename=merge2_fn)
-        ptreader = catalog.PTReader(path, create_domain, exclude=exclude)
-        pyreader = catalog.PYReader(path, create_domain, exclude=exclude)
-        gsreader = catalog.GSReader(path, create_domain, exclude=exclude)
-        zcmlreader = catalog.ZCMLReader(path, create_domain, exclude=exclude)
+        ptreader = catalog.PTReader(
+            path, create_domain, exclude=exclude, no_line_numbers=no_line_numbers
+        )
+        pyreader = catalog.PYReader(
+            path, create_domain, exclude=exclude, no_line_numbers=no_line_numbers
+        )
+        gsreader = catalog.GSReader(
+            path, create_domain, exclude=exclude, no_line_numbers=no_line_numbers
+        )
+        zcmlreader = catalog.ZCMLReader(
+            path, create_domain, exclude=exclude, no_line_numbers=no_line_numbers
+        )
     except IOError as e:
         short_usage(0, 'I/O Error: %s' % e)
 

--- a/src/i18ndude/tests/test_catalog.py
+++ b/src/i18ndude/tests/test_catalog.py
@@ -403,14 +403,14 @@ class TestMessagePoWriter(unittest.TestCase):
         # Restore original value.
         utils.WRAP = orig_wrap
 
-        input = open(self.input, 'r')
+        input_ = open(self.input, 'r')
         output = open(self.output, 'r')
 
         # compare line by line
-        inlines = input.readlines()
+        inlines = input_.readlines()
         outlines = enumerate(output.readlines())
 
-        input.close()
+        input_.close()
         output.close()
 
         for i, result in outlines:
@@ -456,32 +456,31 @@ class TestMessagePoWriter(unittest.TestCase):
 
 class TestMessagePTReader(unittest.TestCase):
 
-    def setUp(self):
-        self.me = catalog.MessageEntry
-        self.input = os.path.join(TESTDATA_DIR, 'input')
-        filename = self.input + os.sep + 'test1.pt'
-        filename3 = self.input + os.sep + 'test3.pt'
-        filename5 = self.input + os.sep + 'test5.pt'
-        self.output = {
-            u'Buzz': self.me(u'Buzz', references=[filename + ':21']),
-            u'${foo} ${with-dash-and_underscore}': self.me(u'${foo} ${with-dash-and_underscore}', references=[filename + ':26']),  # noqa
-            u'dig_this': self.me(u'dig_this', msgstr=u'Dig this', references=[filename + ':52']),  # noqa
-            u'text_buzz': self.me(u'text_buzz', msgstr=u'Buzz', references=[filename + ':29', filename + ':31']),  # noqa
-            u'some_alt': self.me(u'some_alt', msgstr=u'Some alt', references=[filename + ':15', filename3 + ':15']),  # noqa
-            u'title_some_alt': self.me(u'title_some_alt', msgstr=u'Some title', references=[filename + ':15']),  # noqa
-            u'Job started at ${datetime} by user ${userid}.': self.me(u'Job started at ${datetime} by user ${userid}.', references=[filename + ':46']),  # noqa
-            u'spacing': self.me(u'spacing', msgstr=u'Space <br /> before and after.', references=[filename + ':37']),  # noqa
-            u'spacing_strong': self.me(u'spacing_strong', msgstr=u'Please press your browser\'s <strong>Back</strong> button to try again.', references=[filename + ':41']),  # noqa
-            u'<tt>domain</tt> is one of the <em>local domains</em>:': self.me(u'<tt>domain</tt> is one of the <em>local domains</em>:', references=[filename + ':49']),  # noqa
-            u'odd': self.me(u'odd', references=[filename + ':58']),
-            u'even': self.me(u'even', references=[filename + ':59']),
-            u'Test for issue 15, html5 attributes without value': self.me(u'Test for issue 15, html5 attributes without value', references=[filename + ':62']),  # noqa
-            u'rebuild-pot should not complain about Chameleon repeat syntax.': self.me(u'rebuild-pot should not complain about Chameleon repeat syntax.', references=[filename5 + ':16']),  # noqa
-            u'rebuild-pot should not complain about Chameleon define syntax.': self.me(u'rebuild-pot should not complain about Chameleon define syntax.', references=[filename5 + ':19']),  # noqa
+    def test_read_no_line_numbers(self):
+        me = catalog.MessageEntry
+        input_ = os.path.join(TESTDATA_DIR, 'input')
+        filename = input_ + os.sep + 'test1.pt'
+        filename3 = input_ + os.sep + 'test3.pt'
+        filename5 = input_ + os.sep + 'test5.pt'
+        output = {
+            u'Buzz': me(u'Buzz', references=[filename]),
+            u'${foo} ${with-dash-and_underscore}': me(u'${foo} ${with-dash-and_underscore}', references=[filename]),  # noqa
+            u'dig_this': me(u'dig_this', msgstr=u'Dig this', references=[filename]),  # noqa
+            u'text_buzz': me(u'text_buzz', msgstr=u'Buzz', references=[filename]),  # noqa
+            u'some_alt': me(u'some_alt', msgstr=u'Some alt', references=[filename, filename3]),  # noqa
+            u'title_some_alt': me(u'title_some_alt', msgstr=u'Some title', references=[filename]),  # noqa
+            u'Job started at ${datetime} by user ${userid}.': me(u'Job started at ${datetime} by user ${userid}.', references=[filename]),  # noqa
+            u'spacing': me(u'spacing', msgstr=u'Space <br /> before and after.', references=[filename]),  # noqa
+            u'spacing_strong': me(u'spacing_strong', msgstr=u'Please press your browser\'s <strong>Back</strong> button to try again.', references=[filename]),  # noqa
+            u'<tt>domain</tt> is one of the <em>local domains</em>:': me(u'<tt>domain</tt> is one of the <em>local domains</em>:', references=[filename]),  # noqa
+            u'odd': me(u'odd', references=[filename]),
+            u'even': me(u'even', references=[filename]),
+            u'Test for issue 15, html5 attributes without value': me(u'Test for issue 15, html5 attributes without value', references=[filename]),  # noqa
+            u'rebuild-pot should not complain about Chameleon repeat syntax.': me(u'rebuild-pot should not complain about Chameleon repeat syntax.', references=[filename5]),  # noqa
+            u'rebuild-pot should not complain about Chameleon define syntax.': me(u'rebuild-pot should not complain about Chameleon define syntax.', references=[filename5]),  # noqa
         }
 
-    def test_read(self):
-        ptr = catalog.PTReader(self.input, domain='testing')
+        ptr = catalog.PTReader(input_, domain='testing', no_line_numbers=True)
         with warnings.catch_warnings(record=True) as log:
             warnings.simplefilter("always")
             # This call will give a warning from zope.tal.
@@ -502,137 +501,268 @@ class TestMessagePTReader(unittest.TestCase):
         out = ptr.catalogs['testing']
         for key in out:
             self.assertTrue(
-                key in self.output,
+                key in output,
                 'Failure in pt parsing.\nUnexpected msgid: %s' % key
             )
-        for key in self.output:
-            self.assertTrue(out[key] == self.output[key],
+        for key in output:
+            self.assertTrue(out[key] == output[key],
                             'Failure in pt parsing.\nGot:%s\nExpected:%s' %
-                            (out[key], self.output[key]))
-        self.assertEqual(len(out), len(self.output))
+                            (out[key], output[key]))
+        self.assertEqual(len(out), len(output))
+
+    def test_read_with_line_numbers(self):
+        me = catalog.MessageEntry
+        input_ = os.path.join(TESTDATA_DIR, 'input')
+        filename = input_ + os.sep + 'test1.pt'
+        filename3 = input_ + os.sep + 'test3.pt'
+        filename5 = input_ + os.sep + 'test5.pt'
+        output = {
+            u'Buzz': me(u'Buzz', references=[filename + ':21']),
+            u'${foo} ${with-dash-and_underscore}': me(u'${foo} ${with-dash-and_underscore}', references=[filename + ':26']),  # noqa
+            u'dig_this': me(u'dig_this', msgstr=u'Dig this', references=[filename + ':52']),  # noqa
+            u'text_buzz': me(u'text_buzz', msgstr=u'Buzz', references=[filename + ':29', filename + ':31']),  # noqa
+            u'some_alt': me(u'some_alt', msgstr=u'Some alt', references=[filename + ':15', filename3 + ':15']),  # noqa
+            u'title_some_alt': me(u'title_some_alt', msgstr=u'Some title', references=[filename + ':15']),  # noqa
+            u'Job started at ${datetime} by user ${userid}.': me(u'Job started at ${datetime} by user ${userid}.', references=[filename + ':46']),  # noqa
+            u'spacing': me(u'spacing', msgstr=u'Space <br /> before and after.', references=[filename + ':37']),  # noqa
+            u'spacing_strong': me(u'spacing_strong', msgstr=u'Please press your browser\'s <strong>Back</strong> button to try again.', references=[filename + ':41']),  # noqa
+            u'<tt>domain</tt> is one of the <em>local domains</em>:': me(u'<tt>domain</tt> is one of the <em>local domains</em>:', references=[filename + ':49']),  # noqa
+            u'odd': me(u'odd', references=[filename + ':58']),
+            u'even': me(u'even', references=[filename + ':59']),
+            u'Test for issue 15, html5 attributes without value': me(u'Test for issue 15, html5 attributes without value', references=[filename + ':62']),  # noqa
+            u'rebuild-pot should not complain about Chameleon repeat syntax.': me(u'rebuild-pot should not complain about Chameleon repeat syntax.', references=[filename5 + ':16']),  # noqa
+            u'rebuild-pot should not complain about Chameleon define syntax.': me(u'rebuild-pot should not complain about Chameleon define syntax.', references=[filename5 + ':19']),  # noqa
+        }
+
+        ptr = catalog.PTReader(input_, domain='testing')
+        with warnings.catch_warnings(record=True) as log:
+            warnings.simplefilter("always")
+            # This call will give a warning from zope.tal.
+            ptr.read()
+            self.assertGreaterEqual(len(log), 1, log)
+            contents = '\n'.join([str(x.message) for x in log])
+            # Check that a few key elements are in the
+            # warning, without wanting to check the exact
+            # wording, as this can easily change.
+            self.assertTrue("already exists with a different default"
+                            in contents, 'missing "already exists"')
+            self.assertTrue("bad: b'Buzzer', should be: b'Buzz'"  # py36
+                            in contents or
+                            "bad: Buzzer, should be: Buzz"  # py27
+                            in contents,
+                            u'bad Buzzer not in contents: {}'.format(contents))
+
+        out = ptr.catalogs['testing']
+        for key in out:
+            self.assertTrue(
+                key in output,
+                'Failure in pt parsing.\nUnexpected msgid: %s' % key
+            )
+        for key in output:
+            self.assertTrue(out[key] == output[key],
+                            'Failure in pt parsing.\nGot:%s\nExpected:%s' %
+                            (out[key], output[key]))
+        self.assertEqual(len(out), len(output))
 
 
 class TestMessagePYReader(unittest.TestCase):
 
-    def setUp(self):
-        self.me = catalog.MessageEntry
+    def test_read_py_no_line_numbers(self):
+        me = catalog.MessageEntry
         dirpath = os.path.join(TESTDATA_DIR, 'input')
         filepath = os.path.join(dirpath, 'test2.py')
-        self.input = dirpath
-        self.output = {
-            u'Zero': self.me(u'Zero', references=[filepath + ':4']),
-            u'One': self.me(u'One', references=[filepath + ':5']),
-            u'msgid_three': self.me(u'msgid_three', msgstr='Three', references=[filepath + ':10']),  # noqa
-            u'msgid_four': self.me(u'msgid_four', msgstr='Four ${map}', references=[filepath + ':13']),  # noqa
-            u'msgid_five': self.me(u'msgid_five', msgstr=u"五番目", references=[filepath + ':17']),  # noqa
-            u'msgid_six': self.me(u'msgid_six', msgstr=u"\nLine 1\nLine 2\nLine 3\n", references=[filepath + ':19']),  # noqa
+        input_ = dirpath
+        output = {
+            u'Zero': me(u'Zero', references=[filepath]),
+            u'One': me(u'One', references=[filepath]),
+            u'msgid_three': me(u'msgid_three', msgstr='Three', references=[filepath]),  # noqa
+            u'msgid_four': me(u'msgid_four', msgstr='Four ${map}', references=[filepath]),  # noqa
+            u'msgid_five': me(u'msgid_five', msgstr=u"五番目", references=[filepath]),  # noqa
+            u'msgid_six': me(u'msgid_six', msgstr=u"\nLine 1\nLine 2\nLine 3\n", references=[filepath]),  # noqa
             # XXX This should not be found as it's in a different domain
             # instead it recognizes the domain as a msgstr now
-            u'Out1': self.me(u'Out1', msgstr='running', references=[filepath + ':7'])  # noqa
+            u'Out1': me(u'Out1', msgstr='running', references=[filepath])  # noqa
         }
 
-    def test_read_py(self):
-        pyr = catalog.PYReader(self.input, 'testing')
+        pyr = catalog.PYReader(input_, 'testing', no_line_numbers=True)
         pyr.read()
         out = pyr.catalogs['testing']
         for key in out:
             self.assertTrue(
-                key in self.output,
+                key in output,
                 'Failure in py parsing.\nUnexpected msgid: %s' % key)
-        for key in self.output:
+        for key in output:
             self.assertTrue(
                 out.get(key, False),
-                'Failure in py parsing.\nMissing:%s' % self.output.get(key))
+                'Failure in py parsing.\nMissing:%s' % output.get(key))
             self.assertTrue(
-                out.get(key) == self.output.get(key),
+                out.get(key) == output.get(key),
                 'Failure in py parsing.\nGot:%s\nExpected:%s' %
-                (out.get(key), self.output.get(key))
+                (out.get(key), output.get(key))
             )
-        self.assertEqual(len(out), len(self.output))
+        self.assertEqual(len(out), len(output))
+
+    def test_read_py_with_line_numbers(self):
+        me = catalog.MessageEntry
+        dirpath = os.path.join(TESTDATA_DIR, 'input')
+        filepath = os.path.join(dirpath, 'test2.py')
+        input_ = dirpath
+        output = {
+            u'Zero': me(u'Zero', references=[filepath + ':4']),
+            u'One': me(u'One', references=[filepath + ':5']),
+            u'msgid_three': me(u'msgid_three', msgstr='Three', references=[filepath + ':10']),  # noqa
+            u'msgid_four': me(u'msgid_four', msgstr='Four ${map}', references=[filepath + ':13']),  # noqa
+            u'msgid_five': me(u'msgid_five', msgstr=u"五番目", references=[filepath + ':17']),  # noqa
+            u'msgid_six': me(u'msgid_six', msgstr=u"\nLine 1\nLine 2\nLine 3\n", references=[filepath + ':19']),  # noqa
+            # XXX This should not be found as it's in a different domain
+            # instead it recognizes the domain as a msgstr now
+            u'Out1': me(u'Out1', msgstr='running', references=[filepath + ':7'])  # noqa
+        }
+
+        pyr = catalog.PYReader(input_, 'testing')
+        pyr.read()
+        out = pyr.catalogs['testing']
+        for key in out:
+            self.assertTrue(
+                key in output,
+                'Failure in py parsing.\nUnexpected msgid: %s' % key)
+        for key in output:
+            self.assertTrue(
+                out.get(key, False),
+                'Failure in py parsing.\nMissing:%s' % output.get(key))
+            self.assertTrue(
+                out.get(key) == output.get(key),
+                'Failure in py parsing.\nGot:%s\nExpected:%s' %
+                (out.get(key), output.get(key))
+            )
+        self.assertEqual(len(out), len(output))
 
 
 class TestMessageGSReader(unittest.TestCase):
 
-    def setUp(self):
-        self.me = catalog.MessageEntry
+    def test_read_no_line_numbers(self):
+        # GSReader has actually never supported line numbers.
+        me = catalog.MessageEntry
         dirpath = os.path.join(TESTDATA_DIR, 'input')
         filepath = os.path.join(dirpath, 'test.xml')
-        self.input = dirpath
-        self.output = {
+        input_ = dirpath
+        output = {
             u'RSS feed':
-                self.me(u'RSS feed',
+                me(u'RSS feed',
                         references=[filepath]),
             u'Print this':
-                self.me(u'Print this',
+                me(u'Print this',
                         references=[filepath]),
         }
 
-    def test_read(self):
-        reader = catalog.GSReader(self.input, 'plone')
+        reader = catalog.GSReader(input_, 'plone')
         reader.read()
         out = reader.catalogs['plone']
         for key in out:
             self.assertTrue(
-                key in self.output,
+                key in output,
                 'Failure in gs parsing.\nUnexpected msgid: %s' % key)
-        for key in self.output:
+        for key in output:
             self.assertTrue(
                 out.get(key, False),
-                'Failure in gs parsing.\nMissing:%s' % self.output.get(key))
+                'Failure in gs parsing.\nMissing:%s' % output.get(key))
             self.assertTrue(
-                out.get(key) == self.output.get(key),
+                out.get(key) == output.get(key),
                 'Failure in gs parsing.\nGot:%s\nExpected:%s' %
-                (out.get(key), self.output.get(key))
+                (out.get(key), output.get(key))
             )
-        self.assertEqual(len(out), len(self.output))
+        self.assertEqual(len(out), len(output))
 
 
 class TestMessageZCMLReader(unittest.TestCase):
 
-    def setUp(self):
-        self.me = catalog.MessageEntry
+    def test_read_no_line_numbers(self):
+        me = catalog.MessageEntry
         dirpath = os.path.join(TESTDATA_DIR, 'input')
         filepath = os.path.join(dirpath, 'test.zcml')
-        self.input = dirpath
-        self.output = {
+        input_ = dirpath
+        output = {
             u'Plone Site':
-                self.me(u'Plone Site',
-                        references=[filepath + ':14']),
+                me(u'Plone Site',
+                        references=[filepath]),
             u'Profile for a default Plone.':
-                self.me(u'Profile for a default Plone.',
-                        references=[filepath + ':14']),
+                me(u'Profile for a default Plone.',
+                        references=[filepath]),
             u'Mandatory dependencies for a Plone site':
-                self.me(u'Mandatory dependencies for a Plone site',
-                        references=[filepath + ':22']),
+                me(u'Mandatory dependencies for a Plone site',
+                        references=[filepath]),
             u'Adds title and description fields.':
-                self.me(u'Adds title and description fields.',
-                        references=[filepath + ':42']),
+                me(u'Adds title and description fields.',
+                        references=[filepath]),
             u'Basic metadata':
-                self.me(u'Basic metadata',
-                        references=[filepath + ':42']),
+                me(u'Basic metadata',
+                        references=[filepath]),
             u'Content rule names should be translated.':
-                self.me(u'Content rule names should be translated.',
-                        references=[filepath + ':53']),
+                me(u'Content rule names should be translated.',
+                        references=[filepath]),
         }
 
-    def test_read(self):
-        reader = catalog.ZCMLReader(self.input, 'plone')
+        reader = catalog.ZCMLReader(input_, 'plone', no_line_numbers=True)
         reader.read()
         out = reader.catalogs['plone']
         for key in out:
             self.assertTrue(
-                key in self.output,
+                key in output,
                 'Failure in zcml parsing.\nUnexpected msgid: %s' % key)
-        for key in self.output:
+        for key in output:
             self.assertTrue(
                 out.get(key, False),
-                'Failure in zcml parsing.\nMissing:%s' % self.output.get(key))
+                'Failure in zcml parsing.\nMissing:%s' % output.get(key))
             self.assertTrue(
-                out.get(key) == self.output.get(key),
+                out.get(key) == output.get(key),
                 'Failure in zcml parsing.\nGot:%s\nExpected:%s' %
-                (out.get(key), self.output.get(key))
+                (out.get(key), output.get(key))
             )
-        self.assertEqual(len(out), len(self.output))
+        self.assertEqual(len(out), len(output))
+
+    def test_read_with_line_numbers(self):
+        me = catalog.MessageEntry
+        dirpath = os.path.join(TESTDATA_DIR, 'input')
+        filepath = os.path.join(dirpath, 'test.zcml')
+        input_ = dirpath
+        output = {
+            u'Plone Site':
+                me(u'Plone Site',
+                        references=[filepath + ':14']),
+            u'Profile for a default Plone.':
+                me(u'Profile for a default Plone.',
+                        references=[filepath + ':14']),
+            u'Mandatory dependencies for a Plone site':
+                me(u'Mandatory dependencies for a Plone site',
+                        references=[filepath + ':22']),
+            u'Adds title and description fields.':
+                me(u'Adds title and description fields.',
+                        references=[filepath + ':42']),
+            u'Basic metadata':
+                me(u'Basic metadata',
+                        references=[filepath + ':42']),
+            u'Content rule names should be translated.':
+                me(u'Content rule names should be translated.',
+                        references=[filepath + ':53']),
+        }
+
+        reader = catalog.ZCMLReader(input_, 'plone')
+        reader.read()
+        out = reader.catalogs['plone']
+        for key in out:
+            self.assertTrue(
+                key in output,
+                'Failure in zcml parsing.\nUnexpected msgid: %s' % key)
+        for key in output:
+            self.assertTrue(
+                out.get(key, False),
+                'Failure in zcml parsing.\nMissing:%s' % output.get(key))
+            self.assertTrue(
+                out.get(key) == output.get(key),
+                'Failure in zcml parsing.\nGot:%s\nExpected:%s' %
+                (out.get(key), output.get(key))
+            )
+        self.assertEqual(len(out), len(output))
 
 
 def test_suite():


### PR DESCRIPTION
Fixes https://github.com/collective/i18ndude/issues/77

Note for reviewers: a few related test classes had some lines in `setUp` and then one `test_read` method. I have merged these methods and then duplicated them into `test_read_no_line_numbers` and `test_read_with_line_numbers`. Very little of the `setUp` was useful for sharing.