### PR TITLE
Create .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: i18ndude
+  name: i18ndude
+  entry: i18ndude
+  language: python
+  files: ".*.(py|pt|zpt|zcml)$"
+  args: ["find-untranslated"]
+  require_serial: false
+  additional_dependencies: []


### PR DESCRIPTION
For now only to find the strings not marked for translation.

I guess it is possible to add more that one hook right? I haven't seen any example of it though.

We could 

Closes #102 

/cc @ale-rt 
