### PR TITLE
Fix pre-commit integration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
   entry: i18ndude
   language: python
   files: ".*.(pt|zpt)$"
-  args: ["find-untranslated"]
+  args: ["find-untranslated", "-n"]
   require_serial: false
   additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: i18ndude
   entry: i18ndude
   language: python
-  files: ".*.(py|pt|zpt|zcml)$"
+  files: ".*.(pt|zpt)$"
   args: ["find-untranslated"]
   require_serial: false
   additional_dependencies: []

--- a/news/1.bugfix
+++ b/news/1.bugfix
@@ -1,0 +1,2 @@
+Fix pre-commit integration.
+[gforcada]


### PR DESCRIPTION
Checking python files was a bad idea, `i18ndude` is not meant to search for strings not marked for translation there 😅 

Almost the same with `ZCML` files, it might be a second hook that `i18ndude` can provide 💡 

While at it, report only the errors `-n` rather the quite verbose default output.