### PR TITLE
Let i18n:ignore ignore all translatable strings in its scope.

### DIFF
--- a/news/109.feature
+++ b/news/109.feature
@@ -1,0 +1,1 @@
+Let i18n:ignore ignore all translatable strings in its scope.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "6.0.1.dev0"
+version = "6.1.0.dev0"
 
 setup(
     name="i18ndude",

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -222,7 +222,7 @@ class Handler(xml.sax.ContentHandler):
             self._i18nlevel += 1
         elif self._i18nlevel != 0:
             self._i18nlevel += 1
-        if IGNORE_UNTRANSLATED in attrs.keys():
+        if IGNORE_UNTRANSLATED in attrs:
             self._ignore_untranslated = True
         if not self._ignore_untranslated:
             attr_validator(tag, attrs, self.log)
@@ -247,7 +247,7 @@ class Handler(xml.sax.ContentHandler):
 
         if self._i18nlevel != 0:
             self._i18nlevel -= 1
-        if IGNORE_UNTRANSLATED in attrs.keys():
+        if IGNORE_UNTRANSLATED in attrs:
             # reset
             self._ignore_untranslated = False
 

--- a/src/i18ndude/untranslated.py
+++ b/src/i18ndude/untranslated.py
@@ -202,9 +202,14 @@ class Handler(xml.sax.ContentHandler):
         self._filename = filename
 
     def startDocument(self):
-        self._history = []  # history contains 3-tuples in the form
+        # history contains 3-tuples in the form
         # (tag, attrs, characterdata)
-        self._i18nlevel = 0  # 0 means not inside i18n:translate area
+        self._history = []
+        # 0 means not inside i18n:translate area
+        self._i18nlevel = 0
+        # When you add i18n:ignore on a tag, then all untranslated messages on this
+        # or enclosed tags are ignored.
+        self._ignore_untranslated = False
         self._stats = {"WARNING": 0, "ERROR": 0, "FATAL": 0}
 
     def endDocument(self):
@@ -213,36 +218,38 @@ class Handler(xml.sax.ContentHandler):
     def startElement(self, tag, attrs):
         self._history.append([tag, attrs, ""])
 
-        attr_validator(tag, attrs, self.log)
-
         if "i18n:translate" in attrs.keys():
             self._i18nlevel += 1
         elif self._i18nlevel != 0:
             self._i18nlevel += 1
+        if IGNORE_UNTRANSLATED in attrs.keys():
+            self._ignore_untranslated = True
+        if not self._ignore_untranslated:
+            attr_validator(tag, attrs, self.log)
 
     def endElement(self, tag):
         tag, attrs, data = self._history.pop()
         data = data.strip()
 
-        if _translatable(data) and not _tal_replaced_content(tag, attrs):
-            # not enclosed
-            if (self._i18nlevel == 0) and tag not in ["script", "style", "html"]:
-                severity = _severity(tag, attrs) or ""
-                if severity:
-                    if IGNORE_UNTRANSLATED in attrs.keys():
-                        # Ignore untranslated data. This is necessary for
-                        # including literal content, that does not need to be
-                        # translated.
-                        pass
-                    elif not CHAMELEON_SUBST.match(data):
-                        self.log(
-                            "i18n:translate missing for this:\n"
-                            '"""\n%s\n"""' % (data,),
-                            severity,
-                        )
+        if (
+            not self._ignore_untranslated
+            and _translatable(data)
+            and not _tal_replaced_content(tag, attrs)
+            and (self._i18nlevel == 0)
+            and tag not in ["script", "style", "html"]
+        ):
+            severity = _severity(tag, attrs) or ""
+            if severity and not CHAMELEON_SUBST.match(data):
+                self.log(
+                    "i18n:translate missing for this:\n" '"""\n%s\n"""' % (data,),
+                    severity,
+                )
 
         if self._i18nlevel != 0:
             self._i18nlevel -= 1
+        if IGNORE_UNTRANSLATED in attrs.keys():
+            # reset
+            self._ignore_untranslated = False
 
     def characters(self, data):
         self._history[-1][2] += data


### PR DESCRIPTION
Main use case: add i18n:ignore in the top level tag of a template to let the find-untranslated command ignore the complete template. This is useful when you know that all managers or editors can read English, so need no translation.
The alternative would be to add an `--exclude` parameter to the `find-untranslated` command.

This PR builds on PR #108 which cleans up the code.  So you may want to review that first.